### PR TITLE
Fix YAML load warning (https://msg.pyyaml.org/load)

### DIFF
--- a/pgantomizer/anonymize.py
+++ b/pgantomizer/anonymize.py
@@ -140,7 +140,7 @@ def anonymize_db(schema, db_args):
 
 
 def load_anonymize_remove(dump_file, schema, leave_dump=False, db_args=None):
-    schema = yaml.load(open(schema))
+    schema = yaml.load(open(schema), Loader=yaml.FullLoader)
     db_args = db_args or get_db_args_from_env()
     try:
         load_db_to_new_instance(dump_file, db_args)

--- a/pgantomizer/dump.py
+++ b/pgantomizer/dump.py
@@ -8,7 +8,7 @@ import yaml
 
 
 def dump_db(dump_path, schema_path, password='', *db_args):
-    schema = yaml.load(open(schema_path))
+    schema = yaml.load(open(schema_path), Loader=yaml.FullLoader)
     password = password or os.environ.get('DB_DEFAULT_PASS', '')
     os.putenv('PGPASSWORD', password)
     cmd = 'PGPASSWORD={password} pg_dump -Fc -Z 9 {args} {tables} -f {filename}'.format(


### PR DESCRIPTION
I've tried to run the test with Python 3.7.3, PyYAML 5.1 and got the deprecated warning so I fix with the recommendation from https://msg.pyyaml.org/load